### PR TITLE
Fixes units issue when uptime amount is displayed in HH:MM format

### DIFF
--- a/cacher.py
+++ b/cacher.py
@@ -679,7 +679,18 @@ def get_uptime():
         output, err = proc.communicate()
         splitout = str.split(output)
         uptimeamount = splitout[2]
+        # Uptime Type to use if units are "less than days"
         uptimetype = splitout[3].replace(',', '')
+        if uptimeamount[-1:]==',':
+            # Last char is a comma; this likely indicates that the
+            # `uptimetype` is in hours and not in a "greater" unit
+            uptimeamount = uptimeamount[:-1] # get rid of the comma at the end
+            uptimeamount = uptimeamount.split(':')
+            hourtype = ' hour, ' if uptimeamount[0]==1 else ' hours, '
+            uptimeamount = uptimeamount[0] + hourtype + uptimeamount[1]
+            # `uptimetype` to use if main units are in hours and minutes,
+            # which is not the best way to handle this... but it works.
+            uptimetype = 'minutes'
         return '%s %s' % (uptimeamount, uptimetype)
     except Exception:
         return None


### PR DESCRIPTION
When `/usr/bin/uptime` uptime amount is less than 24 hours, the format is displayed in HH:MM format (24hr time), and does not display a unit after the timestamp, unlike when a uptime amount is ≥24 hours, at which point the units change to uptime in days. 
When the timestamp is outputted/displayed when less than 24 hrs, `/usr/bin/uptime` does not include a unit value, but rather displays the uptime amount as a HH:MM timestamp value, and the proceeding "object" in the `splitout` array is actually the integer value of how many open user sessions there are. For example, when there are 3 user sessions logged in with an uptime of 1 hour and 13 minutes, the `/usr/bin/uptime` stdout, the current implementation displays "Uptime" in printouts as "1:13, 3". This output is uninterpretable and can be fixed by observing whether or not a comma follows the [3] element of the `uptime` split output.

The proposed implementation will display the current uptime as "1 hour, 13 minutes" (which will account for 2 "hours" accordingly) when the uptime is less than 24 hours. 

Let me know if this proposed change is poorly coded. It was whatever immediately came to mind with some minor tweaks and refactoring, but it could probably use some fine-tuning. Of course, there are many ways to reach the same output... this is just one of them! 

Thanks for your considerations! Love the script!