### PR TITLE
Adds Friendly Darwin versions for macOS 10.12.4 and 10.12.5

### DIFF
--- a/cacher.py
+++ b/cacher.py
@@ -61,6 +61,8 @@ def cacher(lines, targetDate, friendlyNames):
     # the macOS version (for the alert), while dynamically looping through the
     # logs.
     friendlyDarwin = {
+        '16.6.0': '10.12.5',
+        '16.5.0': '10.12.4',
         '16.4.0': '10.12.3',
         '16.3.0': '10.12.2',
         '16.1.0': '10.12.1',


### PR DESCRIPTION
macOS 10.12.5 is still in beta, but the Darwin version is 16.6.0 as confirmed by a test unit I have, as well as the [macOS Sierra Wikipedia page](https://en.wikipedia.org/wiki/MacOS_Sierra#Releases).